### PR TITLE
Feature/boostjoblist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # @w3tec
 
+bitcoinfiles_scanner_.json
+
 ./deploy.sh
 deploy.sh
 # Logs #

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boostpow-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Boost POW API Service",
   "main": "src/app.ts",
   "scripts": {

--- a/src/api/controllers/v1_BoostController.ts
+++ b/src/api/controllers/v1_BoostController.ts
@@ -7,6 +7,7 @@ import { GetBoostJob } from '../services/use_cases/GetBoostJob';
 import { SubmitBoostSolution } from '../services/use_cases/SubmitBoostSolution';
 import { FindBoostResource } from '../services/use_cases/FindBoostResource';
 import { SearchBoostGraph } from '../services/use_cases/SearchBoostGraph';
+import { GetUnredeemedBoostJobList } from '../services/use_cases/GetUnredeemedBoostJobList';
 
 @JsonController()
 export class BoostController {
@@ -14,6 +15,7 @@ export class BoostController {
         private submitBoostJob: SubmitBoostJob,
         private submitBoostSolution: SubmitBoostSolution,
         private getBoostJobStatus: GetBoostJob,
+        private getBoostJobUnredeemedList: GetUnredeemedBoostJobList,
         private findBoostResource: FindBoostResource,
         private searchBoost: SearchBoostGraph
     ) {
@@ -93,6 +95,23 @@ export class BoostController {
             throw e;
         });
     }
+    /**
+     * Get unredeemed Boost Jobs
+     *
+     */
+    @Get('/v1/main/boost/jobs')
+    public async getUnredeemedJobs(
+        @QueryParam('limit') limit = 2000
+    ) {
+        return this.getBoostJobUnredeemedList.run({
+            limit: limit
+        }).then((outcome) => {
+            return outcome;
+        }).catch((e) => {
+            throw e;
+        });
+    }
+
     /**
      * Get boost job status
      *

--- a/src/api/services/use_cases/GetUnredeemedBoostJobList.ts
+++ b/src/api/services/use_cases/GetUnredeemedBoostJobList.ts
@@ -1,0 +1,87 @@
+import { Service } from 'typedi';
+import { UseCase } from './UseCase';
+import { BoostJobRepository } from '../../repositories/BoostJobRepository';
+import { OrmRepository } from 'typeorm-typedi-extensions';
+import { IsNull } from 'typeorm';
+import * as boost from 'boostpow-js';
+import * as bsv from 'bsv';
+import { BoostJob } from '../../../api/models/BoostJob';
+
+@Service()
+export class GetUnredeemedBoostJobList implements UseCase {
+
+    constructor(
+        @OrmRepository() private boostJobRepo: BoostJobRepository,
+    ) {
+    }
+
+    /**
+     * Format the Boost Job into a form easily processed by a stratum mining pool.
+     *
+     * prevHash name is kept to preserve the significant of the field. It is the contenthash in boost
+     * coinbaseValue is the value of the Boost Job Output.
+     * nBits is encoded in the same form as bitcoind from getminingcandidate
+     *
+     * The additional fields are provided in hex and big endian (be) versions for visibility.
+     *
+     * @param job Boost Job to serialize into a form that a stratum mining pool can use
+     */
+    static serializeBoostJob(job: BoostJob): any {
+        const privKey = bsv.PrivateKey.fromWIF(process.env.MINER_PRIV_KEY);
+        try {
+            const boostJobObj = boost.BoostPowJob.fromRawTransaction(job.rawtx);
+            return  {
+                id: job.txid + '-' + job.vout,
+                prevhash: boostJobObj.getContentHex(),
+                coinbaseValue: boostJobObj.getValue(),
+                version: boostJobObj.getCategoryNumber(),
+                nBits: boostJobObj.bits().toString(16),
+                time: Math.round((new Date()).getTime() / 1000),
+                tag: boostJobObj.getTagBuffer().toString('hex'),
+                tagBeStr: boostJobObj.getTagHex(),
+                additionalData: boostJobObj.getAdditionalDataBuffer().toString('hex'),
+                additionalDataBeStr: boostJobObj.getAdditionalDataHex(),
+                userNonce: boostJobObj.getUserNonceBuffer().toString('hex'),
+                userNonceBeStr: boostJobObj.getUserNonceHex(),
+                minerPubKeyHash: privKey.toPublicKey()._getID().toString('hex'),
+                minerPubKeyHashBeStr: privKey.toPublicKey()._getID().toString('hex'),
+                boostJobTxid: boostJobObj.getTxid(),
+                boostJobVout: boostJobObj.getVout(),
+            };
+        } catch (ex) {
+            console.log('ex', ex);
+        }
+        return null;
+    }
+    public async run(params: { limit: number }): Promise<any> {
+        // Get 2000 jobs max at a time
+        let maxLimited = params.limit ? params.limit : 2000;
+        if (maxLimited > 2000) {
+            maxLimited = 2000;
+        }
+        const unredeemedJobs = await this.boostJobRepo.find({
+            where: {
+                spenttxid: IsNull(),
+                spentvout: IsNull()
+            },
+            take: maxLimited,
+            order: {
+                diff: 'ASC',
+            }
+        });
+
+        const resultList = [];
+        for (const job of unredeemedJobs) {
+            const formattedBoostJob = GetUnredeemedBoostJobList.serializeBoostJob(job);
+            if (!formattedBoostJob) {
+                continue;
+            }
+            resultList.push(formattedBoostJob);
+        }
+        return {
+            success: true,
+            result: resultList
+        };
+    }
+}
+


### PR DESCRIPTION
Changes:

- Add route /api/v1/main/boost/jobs
- Retrieves up to 2000 unredeemed boost jobs

This is useful for a mining pool to process Boost outputs.